### PR TITLE
Fixed http methods of `SessionRoutes#deleteCurrent` & `SessionRoutes#deleteById`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.1
+- Fixed http methods of `SessionRoutes#deleteCurrent` & `SessionRoutes#deleteById`
+
 ## 0.8
 - Cache accounts & currencies on startup
   - Added `Restrr#getAccounts`

--- a/lib/src/api/requests/route_definitions.dart
+++ b/lib/src/api/requests/route_definitions.dart
@@ -11,9 +11,9 @@ class SessionRoutes {
   const SessionRoutes._();
 
   static final Route getCurrent = Route.get('/session/current');
-  static final Route deleteCurrent = Route.post('/session/current');
+  static final Route deleteCurrent = Route.delete('/session/current');
   static final Route getById = Route.get('/session/{sessionId}');
-  static final Route deleteById = Route.get('/session/{sessionId}');
+  static final Route deleteById = Route.delete('/session/{sessionId}');
   static final Route getAll = Route.get('/session');
   static final Route deleteAll = Route.delete('/session');
   static final Route create = Route.post('/session');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: restrr
 description: Dart package which allows to communicate with the financrr REST API.
-version: 0.8.0
+version: 0.8.1
 repository: https://github.com/financrr/restrr
 
 environment:


### PR DESCRIPTION
## 0.8.1
- Fixed http methods of `SessionRoutes#deleteCurrent` & `SessionRoutes#deleteById`