### PR TITLE
v0.9.1 — Fixed use of `EntityId<E>` in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.1
+- Fixed use of `EntityId<E>` 
+
 ## 0.9
 - Added `EntityCacheView`
 - Temporary remove page cache

--- a/lib/src/internal/cache/entity_cache_view_impl.dart
+++ b/lib/src/internal/cache/entity_cache_view_impl.dart
@@ -1,25 +1,25 @@
 import 'package:restrr/restrr.dart';
 
 class EntityCacheViewImpl<E extends RestrrEntity<E, ID>, ID extends EntityId<E>> implements EntityCacheView<E, ID> {
-  final Map<ID, E> _cache = {};
+  final Map<Id, E> _cache = {};
 
   @override
-  E? get(ID id) => _cache[id];
+  E? get(ID id) => _cache[id.value];
 
   @override
   List<E> getAll() => _cache.values.toList();
 
   @override
-  E add(E entity) => _cache[entity.id] = entity;
+  E add(E entity) => _cache[entity.id.value] = entity;
 
   @override
-  E? remove(ID id) => _cache.remove(id);
+  E? remove(ID id) => _cache.remove(id.value);
 
   @override
   void removeWhere(bool Function(E p1) predicate) => _cache.removeWhere((k, v) => predicate(v));
 
   @override
-  bool contains(ID id) => _cache.containsKey(id);
+  bool contains(ID id) => _cache.containsKey(id.value);
 
   @override
   void clear() => _cache.clear();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: restrr
 description: Dart package which allows to communicate with the financrr REST API.
-version: 0.9.0
+version: 0.9.1
 repository: https://github.com/financrr/restrr
 
 environment:


### PR DESCRIPTION
## 0.9.1
- Fixed use of `EntityId<E>`